### PR TITLE
docs+ci: add AGENTS.md, update README, align scripts & PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,10 @@
 
 ## Checks
 
-- [ ] Lint passes locally (`yarn lint` if present)
-- [ ] Tests pass (`yarn test`)
+- [ ] Format check passes (`yarn format:check`)
+- [ ] Lint passes (`yarn lint`)
+- [ ] Type-check passes (`yarn tsc --noEmit`)
 - [ ] Build succeeds (`yarn build`)
+- [ ] Optional: Preview locally (`yarn preview`)
 
 ## Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,128 @@
+# AGENTS.md
+
+## Overview
+
+Automated code agents (e.g., Jules, Copilot) assist routine development tasks. This guide defines how agents should plan, code, validate, and contribute so efforts align with this repo’s standards and workflow.
+
+## Main Features & UI (preserve these)
+
+- Interactive Timeline: chronological work history and achievements
+- Skills Showcase: categorized with proficiency badges
+- Ship Log: placeholder component (planned feed for recent updates)
+- Command Menu: Cmd/Ctrl+K palette for navigation/social
+- Theme Toggle: light/dark modes (contrast tokens)
+- Responsive Design: mobile-friendly, accessible, performant
+
+Agents must use idiomatic React + TypeScript patterns and respect the existing folder structure.
+
+## Task & Code Execution Workflow
+
+1) Plan
+
+- Generate a concise step-by-step plan before code changes.
+- If a non-trivial or risky refactor, propose first; wait for approval.
+- Reference the plan/task in PR descriptions.
+
+1) Branch & PR (Trunk-based)
+
+- Base off latest `main`.
+- Small, focused PRs only; conventional commits (feat, fix, chore, docs).
+- Branch naming:
+  - UI improvements: `ui/<feature>` (e.g., `ui/skills`, `ui/command-menu`, `ui/vertical-timeline`)
+  - Non-UI/perf: `perf/<feature>` — current branch in use: `perf/optimizations`
+- Baseline snapshot/tag: `checkpoint/baseline-2025-08-15`
+
+1) Code Standards (order matters)
+
+- Format → Lint → Type-check → Build
+- Keep changes minimal and readable; match repo idioms (React function components, named exports, clear prop types).
+
+## Scripts (Yarn v1 only)
+
+- `yarn start` — dev server (<http://localhost:4000>)
+- `yarn build` — production build to `dist/`
+- `yarn preview` — serves `dist/` (<http://localhost:4000>)
+- `yarn lint` — ESLint on `src/`
+- `yarn tsc --noEmit` — TypeScript type-check only
+- `yarn format` — Prettier write
+- `yarn format:check` — Prettier check
+
+Notes:
+
+- Yarn v1 project; do not commit `package-lock.json`.
+- Node v20 is required/preferred (`.nvmrc`, engines in package.json).
+
+## Quality Gates & CI
+
+CI (GitHub Actions) runs on push/PR:
+
+- Prettier check
+- ESLint
+- TypeScript type-check (`yarn tsc --noEmit`)
+- Vite production build
+- Minimal smoke test (curl) against a temporary preview server (validates key endpoints/meta)
+- Uploads `dist/` artifact for preview on every run
+
+Keep CI lightweight; no heavy/slow suites. Add only fast, deterministic checks.
+
+## Build, Preview & Artifact
+
+- Local build: `yarn build` (outputs to `dist/`)
+- Local preview (artifact or local build):
+
+  ```bash
+  npx serve -s dist -l 4000
+  # open http://localhost:4000
+  ```
+
+- CI artifact preview: download and serve `dist/` as above.
+
+## Deploy
+
+- Not auto-deploying yet; prefer GitHub Pages via `.github/workflows/deploy-pages.yml` when enabled.
+- Vite base must match hosting:
+  - Custom domain/user site: `base: '/'`
+  - Project pages (`https://<user>.github.io/<repo>/`): `base: '/<repo>/'` (trailing slash)
+
+## Project Structure
+
+```
+public/                  # static assets and index.html
+src/
+  components/            # UI components (Header, Timeline, Skills, etc.)
+  content/               # data files (experience.ts, skills.ts, user.ts)
+  hooks/                 # custom React hooks
+  layouts/               # shared layout wrapper(s)
+  styles/                # global styles & design tokens (tokens.css, global.css)
+  main.tsx               # app bootstrap
+```
+
+## Content Schema (for agents updating content)
+
+- **Skills**: grouped into Languages & Runtimes, Frameworks & Libraries, AI/ML & Tooling, Infra & DevOps, Design & UX. Depth: Expert, Proficient, Familiar (legacy: Advanced→Proficient, Intermediate→Familiar). Source: `src/content/skills.ts`
+- **Timeline**: entries include `title`, `company`, `date`, succinct achievements, and technologies. Source: `src/content/experience.ts`
+- **User**: personal details and social links. Source: `src/content/user.ts`
+- See: `src/components/Skills/README.md`, `src/components/Timeline/README.md` for UI notes.
+
+## Editor & Agent Rules
+
+- See `.cursorrules` for editor/agent expectations (formatting, CI, file handling).
+- Respect `.editorconfig` and Prettier.
+- Use Yarn-only workflows (guard exists to prevent `package-lock.json`).
+
+## Security & Privacy
+
+- Never commit secrets or credentials.
+- Minimize dependencies; justify new ones.
+- Keep code and content safe for public distribution.
+
+## Checklist (before opening a PR)
+
+- [ ] `yarn format:check` passes
+- [ ] `yarn lint` passes
+- [ ] `yarn tsc --noEmit` passes
+- [ ] `yarn build` succeeds
+- [ ] Manual sanity check in `yarn preview` (UI changes only)
+- [ ] PR includes plan summary and impact/risk notes
+
+_Last updated: 2025-08-16_

--- a/README.md
+++ b/README.md
@@ -10,11 +10,20 @@ React portfolio site.
 
 React 19 | TypeScript | Vite | Tailwind CSS | Framer Motion | Yarn | Prettier
 
+## Main Features
+
+- Interactive Timeline: chronological overview of experience with roles and achievements
+- Skills Showcase: categorized skills with proficiency badges
+- Ship Log: recent updates and milestones
+- Command Menu: quick command palette (Cmd/Ctrl+K or floating button) for navigation and social links
+- Theme Toggle: light/dark mode with token-driven contrast
+- Responsive Design: mobile-first, accessible, performant
+
 ## Run Locally
 
 1. `git clone https://github.com/n-dryer/personal-site.git`
-2. `cd personal-site && yarn install`
-3. `yarn start` (Vite dev server on `http://localhost:4000`)
+1. `cd personal-site && yarn install`
+1. `yarn start` (Vite dev server on `http://localhost:4000`)
 
 **Quality gates (no heavy test suites):**
 
@@ -29,9 +38,22 @@ React 19 | TypeScript | Vite | Tailwind CSS | Framer Motion | Yarn | Prettier
 - Build production bundle: `yarn build` (outputs to `dist/`)
 - Preview production bundle: `yarn preview` (serves `dist/` on `http://localhost:4000`)
 
+## Project Structure
+
+```
+public/                  # static assets and index.html
+src/
+  components/            # UI components (Header, Timeline, Skills, etc.)
+  content/               # content data (experience.ts, skills.ts, user.ts)
+  hooks/                 # custom React hooks
+  layouts/               # application layout components
+  styles/                # global styles & design tokens (tokens.css, global.css)
+  main.tsx               # app bootstrap
+```
+
 ## CI & Artifact Preview
 
-- Every push/PR runs CI (format check, lint, type-check, build, minimal E2E curl smoke) and uploads the built `dist/` as an artifact.
+- Every push/PR runs CI (format check, lint, type-check via `yarn tsc --noEmit`, build, minimal E2E curl smoke) and uploads the built `dist/` as an artifact.
 - To preview the artifact locally:
 
 ```bash
@@ -41,16 +63,26 @@ npx serve -s dist -l 4000
 # open http://localhost:4000
 ```
 
+### CI logs & artifacts
+
+- View workflow runs and logs under the **Actions** tab.
+- Download the `dist/` artifact from the run summary to preview the exact build produced by CI.
+
 ## Deploy (when ready)
 
-- This project is not auto-deploying yet. When ready, prefer GitHub Actions Pages (`.github/workflows/deploy-pages.yml`).
-- Ensure `vite.config.ts` `base` is `/` for custom domains (current setup), or set it to your repo subpath if deploying under `https://<user>.github.io/<repo>/`.
+- Not auto-deploying yet; prefer GitHub Pages via `.github/workflows/deploy-pages.yml` when enabled.
+- Vite `base` must match hosting:
+  - Custom domain/user site: `base: '/'`
+  - Project pages (`https://<user>.github.io/<repo>/`): `base: '/<repo>/'` (note trailing slash)
 
-## Branching & Releases
+## Branching & PRs
 
-- Baseline snapshot: `baseline/2025-08-15` (tag: `baseline-2025-08-15`)
-- First feature: `feat/vite-migration-react19` → PR into `main`
-- Use conventional commits (feat, fix, chore, docs) and small PRs
+- Trunk-based flow. Create small, focused PRs into `main`.
+- Branch names:
+  - UI improvements: `ui/<feature>` (e.g., `ui/vertical-timeline`, `ui/skills`, `ui/command-menu`)
+  - Non-UI/performance: `perf/optimizations`
+- Use conventional commits (feat, fix, chore, docs).
+- Baseline snapshot is kept as a tag: `checkpoint/baseline-2025-08-15`.
 
 ## Content Schema (Skills & Timeline)
 
@@ -58,6 +90,18 @@ npx serve -s dist -l 4000
 - Timeline entries standardize: role (`title`), `company`, `date`, succinct achievements and technologies.
 
 Update guidelines are documented in `src/components/Skills/README.md` and `src/components/Timeline/README.md`.
+
+## Scripts
+
+| Command                 | Purpose                                   |
+|-------------------------|-------------------------------------------|
+| `yarn start`            | Vite dev server (<http://localhost:4000>)   |
+| `yarn build`            | Production build to `dist/`               |
+| `yarn preview`          | Serves `dist/` at <http://localhost:4000>   |
+| `yarn lint`             | ESLint on `src/`                          |
+| `yarn tsc --noEmit`     | TypeScript type-check                     |
+| `yarn format`           | Prettier write                            |
+| `yarn format:check`     | Prettier check                            |
 
 ## Formatting & Editor setup
 
@@ -77,3 +121,8 @@ yarn format:check
   - `.prettierrc`: pins formatting rules (singleQuote, trailingComma, printWidth)
   - `.editorconfig`: cross-editor settings (LF line endings, UTF-8, 2-space indents)
   - Node version: `.nvmrc` (v20) and `engines.node: ">=20"` in `package.json`
+
+## Agents & Automation
+
+- See `AGENTS.md` for agent/editor guidance (planning, branching, scripts, CI expectations).
+- See `.cursorrules` for additional editor/agent conventions and guardrails.

--- a/package.json
+++ b/package.json
@@ -22,14 +22,15 @@
     "react-scroll-parallax": "^3.4.5"
   },
   "scripts": {
-    "start": "vite",
+    "start": "vite --port 4000",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "vite preview --port 4000",
     "format:check": "prettier --check .",
     "ci:guard:lockfile": "test ! -f package-lock.json || (echo 'package-lock.json detected. Use Yarn only.' && exit 1)",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "tsc": "tsc -p tsconfig.json"
   },
   "homepage": "https://nathandryer.com",
   "license": "MIT",


### PR DESCRIPTION
Summary
- Add AGENTS.md with agent/editor guidance (planning, branching, scripts, CI)
- README: add Agents & Automation section, CI logs/artifacts instructions
- package.json: set dev/preview ports to 4000; add tsc script
- PR template: replace tests checkbox with format/lint/tsc/build/preview

Why
- Improve contributor and agent onboarding; align docs with actual scripts and CI gates

Checks
- format:check, lint, tsc --noEmit, build pass locally

Notes
- Trunk-based workflow; small PRs into main
