### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 permissions:
   contents: read
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/n-dryer/personal-site/security/code-scanning/2](https://github.com/n-dryer/personal-site/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key to restrict the `GITHUB_TOKEN` to the minimum required privileges. In this case, the workflow only needs to read repository contents (for checkout and CI), and does not need to write to the repository, create issues, or modify pull requests. Therefore, add `permissions: contents: read` at the top level of the workflow file (just after the `name:` line and before `on:`), so it applies to all jobs in the workflow. No other changes are needed, as none of the steps require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
