### PR TITLE
feat: add timeline concept switcher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   ScrollDownButton,
   FloatingCommandButton,
   Timeline,
+  TimelineConceptSwitcher,
   Skills,
   CommandMenu,
 } from './components';
@@ -49,6 +50,15 @@ const App = () => {
           fallback={<div className="text-red-500">Something went wrong with the Timeline.</div>}
         >
           <Timeline experienceData={experienceData} />
+        </ErrorBoundary>
+        <ErrorBoundary
+          fallback={
+            <div className="text-red-500">Something went wrong with the timeline concepts.</div>
+          }
+        >
+          <div className="container mx-auto px-4">
+            <TimelineConceptSwitcher />
+          </div>
         </ErrorBoundary>
         <ErrorBoundary
           fallback={

--- a/src/components/TimelineConcepts/GlassTimeline.tsx
+++ b/src/components/TimelineConcepts/GlassTimeline.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+
+interface TimelineEvent {
+  date: string;
+  title: string;
+  description: string;
+  media?: string;
+}
+
+const events: TimelineEvent[] = [
+  {
+    date: '2025-01',
+    title: 'Launched Portfolio',
+    description: 'Showcased projects with 3D visuals.',
+    media: 'screenshot.png',
+  },
+  {
+    date: '2024-06',
+    title: 'Open Source Release',
+    description: 'Published a React library.',
+  },
+];
+
+export const GlassTimeline: React.FC = () => {
+  const [active, setActive] = useState<TimelineEvent | null>(null);
+  return (
+    <div className="relative mx-auto max-w-md pl-6">
+      <div className="absolute left-2 top-0 h-full w-px bg-white/30" />
+      {events.map((ev) => (
+        <div
+          key={ev.date}
+          className="mb-6 cursor-pointer rounded-xl bg-white/20 p-4 shadow-sm backdrop-blur"
+          onClick={() => setActive(ev)}
+        >
+          <time className="block text-xs">{ev.date}</time>
+          <h3 className="font-semibold">{ev.title}</h3>
+        </div>
+      ))}
+      {active && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => setActive(null)}
+        >
+          <div
+            className="max-w-md rounded-xl bg-bg-surface p-6 shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="mb-2 text-xl font-semibold">{active.title}</h2>
+            <p className="mb-4 text-sm text-text-secondary">{active.description}</p>
+            {active.media && <img src={active.media} alt="" className="rounded" />}
+            <button
+              className="mt-4 rounded bg-accent px-4 py-2 text-on-accent"
+              onClick={() => setActive(null)}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/TimelineConcepts/MinimalTimeline.tsx
+++ b/src/components/TimelineConcepts/MinimalTimeline.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+
+interface TimelineEvent {
+  date: string;
+  title: string;
+  description: string;
+}
+
+const events: TimelineEvent[] = [
+  {
+    date: '2024-08',
+    title: 'Joined StartUp X',
+    description: 'Full-stack development with React, Node.js, and cloud functions.',
+  },
+  {
+    date: '2022-05',
+    title: 'Graduated University',
+    description: 'B.S. in Computer Science.',
+  },
+];
+
+export const MinimalTimeline: React.FC = () => {
+  const [openIdx, setOpenIdx] = useState<number | null>(null);
+  return (
+    <div className="relative ml-4 border-l border-text-secondary/20">
+      {events.map((ev, idx) => (
+        <div
+          key={ev.date}
+          className="relative mb-4 cursor-pointer pl-6"
+          onClick={() => setOpenIdx(openIdx === idx ? null : idx)}
+        >
+          <span className="absolute -left-[0.41rem] top-2 h-3 w-3 rounded-full border border-bg-surface bg-accent" />
+          <time className="block text-xs text-text-secondary">{ev.date}</time>
+          <h3 className="font-medium">{ev.title}</h3>
+          {openIdx === idx && <p className="mt-1 text-sm text-text-secondary">{ev.description}</p>}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/TimelineConcepts/TimelineConceptSwitcher.tsx
+++ b/src/components/TimelineConcepts/TimelineConceptSwitcher.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { MinimalTimeline } from './MinimalTimeline';
+import { ZigzagTimeline } from './ZigzagTimeline';
+import { YearAccordionTimeline } from './YearAccordionTimeline';
+import { GlassTimeline } from './GlassTimeline';
+
+type Variant = 'minimal' | 'zigzag' | 'accordion' | 'glass';
+
+const variantMap: Record<Variant, React.ReactNode> = {
+  minimal: <MinimalTimeline />,
+  zigzag: <ZigzagTimeline />,
+  accordion: <YearAccordionTimeline />,
+  glass: <GlassTimeline />,
+};
+
+export const TimelineConceptSwitcher: React.FC = () => {
+  const [variant, setVariant] = useState<Variant>('minimal');
+  return (
+    <section id="timeline-concepts" className="py-[var(--space-section)]">
+      <h2 className="mb-6 text-center font-display text-3xl font-semibold tracking-tight">
+        Timeline Concepts
+      </h2>
+      <div className="mb-8 flex justify-center">
+        <label className="sr-only" htmlFor="timeline-variant">
+          Select timeline variant
+        </label>
+        <select
+          id="timeline-variant"
+          className="rounded border border-text-secondary/20 bg-bg-surface px-3 py-2"
+          value={variant}
+          onChange={(e) => setVariant(e.target.value as Variant)}
+        >
+          <option value="minimal">Minimal</option>
+          <option value="zigzag">Zigzag</option>
+          <option value="accordion">Year Accordion</option>
+          <option value="glass">Glassmorphic</option>
+        </select>
+      </div>
+      <div className="mx-auto max-w-3xl">{variantMap[variant]}</div>
+    </section>
+  );
+};

--- a/src/components/TimelineConcepts/YearAccordionTimeline.tsx
+++ b/src/components/TimelineConcepts/YearAccordionTimeline.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+
+interface TimelineEvent {
+  date: string; // YYYY-MM
+  title: string;
+  description: string;
+}
+
+const events: TimelineEvent[] = [
+  {
+    date: '2024-02',
+    title: 'Promotion to Lead',
+    description: 'Led a new product launch and managed a small team.',
+  },
+  {
+    date: '2023-09',
+    title: 'Joined Company Y',
+    description: 'Started as a front-end engineer.',
+  },
+  {
+    date: '2023-01',
+    title: 'Bootcamp Mentor',
+    description: 'Mentored 30+ students in web development.',
+  },
+];
+
+const grouped = events.reduce<Record<string, TimelineEvent[]>>((acc, ev) => {
+  const year = ev.date.slice(0, 4);
+  (acc[year] ??= []).push(ev);
+  return acc;
+}, {});
+
+export const YearAccordionTimeline: React.FC = () => {
+  const [openYear, setOpenYear] = useState<string | null>(null);
+  const years = Object.keys(grouped).sort((a, b) => Number(b) - Number(a));
+  return (
+    <div className="mx-auto max-w-md">
+      {years.map((year) => (
+        <div key={year} className="mb-4 rounded border border-text-secondary/20">
+          <button
+            className="flex w-full items-center justify-between bg-bg-surface px-4 py-2 font-medium"
+            onClick={() => setOpenYear(openYear === year ? null : year)}
+          >
+            {year}
+            <span>{openYear === year ? '-' : '+'}</span>
+          </button>
+          {openYear === year && (
+            <ul className="space-y-2 px-4 py-2">
+              {grouped[year]
+                .sort((a, b) => (a.date > b.date ? -1 : 1))
+                .map((ev) => (
+                  <li key={ev.date}>
+                    <time className="block text-xs text-text-secondary">{ev.date}</time>
+                    <h4 className="font-semibold">{ev.title}</h4>
+                    <p className="text-sm text-text-secondary">{ev.description}</p>
+                  </li>
+                ))}
+            </ul>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/TimelineConcepts/YearAccordionTimeline.tsx
+++ b/src/components/TimelineConcepts/YearAccordionTimeline.tsx
@@ -46,7 +46,7 @@ export const YearAccordionTimeline: React.FC = () => {
           </button>
           {openYear === year && (
             <ul className="space-y-2 px-4 py-2">
-              {grouped[year]
+              {[...grouped[year]]
                 .sort((a, b) => (a.date > b.date ? -1 : 1))
                 .map((ev) => (
                   <li key={ev.date}>

--- a/src/components/TimelineConcepts/ZigzagTimeline.tsx
+++ b/src/components/TimelineConcepts/ZigzagTimeline.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+interface TimelineEvent {
+  date: string;
+  title: string;
+  description: string;
+  icon?: React.ReactNode;
+}
+
+const events: TimelineEvent[] = [
+  {
+    date: '2024',
+    title: 'Hackathon Winner',
+    description: 'Built an AI tool in 24 hours and won the grand prize.',
+    icon: '🏆',
+  },
+  {
+    date: '2023',
+    title: 'Conference Speaker',
+    description: 'Presented modern UI trends at JSConf.',
+    icon: '🎤',
+  },
+];
+
+export const ZigzagTimeline: React.FC = () => (
+  <div className="relative mx-auto max-w-2xl before:absolute before:left-1/2 before:top-0 before:h-full before:w-px before:-translate-x-1/2 before:bg-text-secondary/20">
+    {events.map((ev, idx) => (
+      <div
+        key={ev.date}
+        className={`mb-8 flex items-start ${idx % 2 ? 'flex-row-reverse text-right' : ''}`}
+      >
+        <div className="flex-1 group px-4">
+          <time className="text-xs text-text-secondary">{ev.date}</time>
+          <h3 className="font-semibold">{ev.title}</h3>
+          <p className="mt-1 hidden text-sm text-text-secondary group-hover:block">
+            {ev.description}
+          </p>
+        </div>
+        <div className="mx-4 flex h-8 w-8 items-center justify-center rounded-full bg-accent text-xl">
+          {ev.icon}
+        </div>
+      </div>
+    ))}
+  </div>
+);

--- a/src/components/TimelineConcepts/index.ts
+++ b/src/components/TimelineConcepts/index.ts
@@ -1,0 +1,5 @@
+export * from './MinimalTimeline';
+export * from './ZigzagTimeline';
+export * from './YearAccordionTimeline';
+export * from './GlassTimeline';
+export * from './TimelineConceptSwitcher';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,3 +6,4 @@ export * from './CommandMenu';
 export * from './Skills';
 export * from './ThemeToggle';
 export * from './Timeline';
+export * from './TimelineConcepts';


### PR DESCRIPTION
## Summary
- add four distinct timeline concept components
- provide a switcher to preview timeline variants
- wire the switcher into the main app for demo

## Testing
- `yarn format:check`
- `yarn lint`
- `yarn test`
- `yarn tsc --noEmit`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_68a916445bbc8328a6d62bc2de6e5b87